### PR TITLE
Use LF line endings in selection text

### DIFF
--- a/src/XTerm.NET.Tests/SelectionTests.cs
+++ b/src/XTerm.NET.Tests/SelectionTests.cs
@@ -69,6 +69,25 @@ public class SelectionTests
     }
 
     [Fact]
+    public void SelectionText_UsesLineFeedLineEndings()
+    {
+        var terminal = new Terminal(new TerminalOptions { Rows = 3, Cols = 80, Scrollback = 20 });
+        terminal.Write("alpha\r\nbeta\r\ngamma");
+
+        terminal.Selection.StartSelection(0, 0);
+        terminal.Selection.UpdateSelection(4, 2);
+        terminal.Selection.EndSelection();
+
+        var selectedText = terminal.Selection.GetSelectionText();
+
+        Assert.DoesNotContain("\r", selectedText);
+        Assert.Equal(2, selectedText.Count(ch => ch == '\n'));
+        Assert.StartsWith("alpha", selectedText);
+        Assert.Contains("\nbeta", selectedText);
+        Assert.EndsWith("gamma", selectedText);
+    }
+
+    [Fact]
     public void Selection_IsCleared_WhenTrimRemovesSelectedLines()
     {
         var terminal = new Terminal(new TerminalOptions { Rows = 3, Cols = 80, Scrollback = 2 });

--- a/src/XTerm.NET/Selection/SelectionManager.cs
+++ b/src/XTerm.NET/Selection/SelectionManager.cs
@@ -154,7 +154,7 @@ public class SelectionManager
             // Add line break if not last line and line doesn't wrap
             if (y < end.y && !line.IsWrapped)
             {
-                text.AppendLine();
+                text.Append('\n');
             }
         }
 


### PR DESCRIPTION
## Summary

This makes terminal selection text use `\n` as the internal line separator instead of `StringBuilder.AppendLine()`, which emits platform-dependent line endings.

On Windows, `AppendLine()` produces CRLF before the host application or clipboard layer has a chance to apply its own platform normalization. Keeping XTerm.NET selection text LF-only gives host integrations one clear place to decide clipboard/export line-ending policy.

## Validation

- `dotnet test src\XTerm.NET.slnx`
  - 585 passed, 0 failed