### PR TITLE
Clamp selection text bounds

### DIFF
--- a/src/XTerm.NET.Tests/SelectionTests.cs
+++ b/src/XTerm.NET.Tests/SelectionTests.cs
@@ -104,6 +104,8 @@ public class SelectionTests
         terminal.Selection.EndSelection();
 
         Assert.Equal(string.Empty, terminal.Selection.GetSelectionText());
+    }
+    
     public void SelectionText_UsesLineFeedLineEndings()
     {
         var terminal = new Terminal(new TerminalOptions { Rows = 3, Cols = 80, Scrollback = 20 });

--- a/src/XTerm.NET.Tests/SelectionTests.cs
+++ b/src/XTerm.NET.Tests/SelectionTests.cs
@@ -69,6 +69,32 @@ public class SelectionTests
     }
 
     [Fact]
+    public void SelectionText_ClampsNegativeColumns()
+    {
+        var terminal = new Terminal(new TerminalOptions { Rows = 3, Cols = 10, Scrollback = 20 });
+        terminal.Write("alpha");
+
+        terminal.Selection.StartSelection(-3, 0);
+        terminal.Selection.UpdateSelection(4, 0);
+        terminal.Selection.EndSelection();
+
+        Assert.Equal("alpha", terminal.Selection.GetSelectionText());
+    }
+
+    [Fact]
+    public void SelectionText_ClampsColumnsPastRightEdge()
+    {
+        var terminal = new Terminal(new TerminalOptions { Rows = 3, Cols = 10, Scrollback = 20 });
+        terminal.Write("alpha");
+
+        terminal.Selection.StartSelection(0, 0);
+        terminal.Selection.UpdateSelection(30, 0);
+        terminal.Selection.EndSelection();
+
+        Assert.StartsWith("alpha", terminal.Selection.GetSelectionText());
+    }
+
+    [Fact]
     public void Selection_IsCleared_WhenTrimRemovesSelectedLines()
     {
         var terminal = new Terminal(new TerminalOptions { Rows = 3, Cols = 80, Scrollback = 2 });

--- a/src/XTerm.NET.Tests/SelectionTests.cs
+++ b/src/XTerm.NET.Tests/SelectionTests.cs
@@ -95,6 +95,18 @@ public class SelectionTests
     }
 
     [Fact]
+    public void SelectionText_ReturnsEmpty_WhenTerminalHasNoColumns()
+    {
+        var terminal = new Terminal(new TerminalOptions { Rows = 3, Cols = 0, Scrollback = 20 });
+
+        terminal.Selection.StartSelection(0, 0);
+        terminal.Selection.UpdateSelection(0, 0);
+        terminal.Selection.EndSelection();
+
+        Assert.Equal(string.Empty, terminal.Selection.GetSelectionText());
+    }
+
+    [Fact]
     public void Selection_IsCleared_WhenTrimRemovesSelectedLines()
     {
         var terminal = new Terminal(new TerminalOptions { Rows = 3, Cols = 80, Scrollback = 2 });

--- a/src/XTerm.NET/Selection/SelectionManager.cs
+++ b/src/XTerm.NET/Selection/SelectionManager.cs
@@ -145,8 +145,11 @@ public class SelectionManager
             if (line == null)
                 continue;
 
-            int startX = (y == start.y) ? start.x : 0;
-            int endX = (y == end.y) ? end.x : _terminal.Cols - 1;
+            int startX = Math.Clamp((y == start.y) ? start.x : 0, 0, _terminal.Cols - 1);
+            int endX = Math.Clamp((y == end.y) ? end.x : _terminal.Cols - 1, 0, _terminal.Cols - 1);
+
+            if (startX > endX)
+                continue;
 
             var lineText = line.TranslateToString(false, startX, endX + 1);
             text.Append(lineText);

--- a/src/XTerm.NET/Selection/SelectionManager.cs
+++ b/src/XTerm.NET/Selection/SelectionManager.cs
@@ -145,8 +145,12 @@ public class SelectionManager
             if (line == null)
                 continue;
 
-            int startX = Math.Clamp((y == start.y) ? start.x : 0, 0, _terminal.Cols - 1);
-            int endX = Math.Clamp((y == end.y) ? end.x : _terminal.Cols - 1, 0, _terminal.Cols - 1);
+            int lastColumn = _terminal.Cols - 1;
+            if (lastColumn < 0)
+                continue;
+
+            int startX = Math.Clamp((y == start.y) ? start.x : 0, 0, lastColumn);
+            int endX = Math.Clamp((y == end.y) ? end.x : lastColumn, 0, lastColumn);
 
             if (startX > endX)
                 continue;


### PR DESCRIPTION
## Summary

This prevents `SelectionManager.GetSelectionText()` from passing out-of-range columns into `BufferLine.TranslateToString()`.

Selection coordinates can come from pointer positions outside the terminal cell grid, for example dragging slightly left of the terminal before copying. A negative start column can currently produce an `IndexOutOfRangeException` while translating the selected line.

The fix clamps start and end columns to the valid terminal column range before translating each selected line.

## Validation

- `dotnet test src\XTerm.NET.slnx`
  - 586 passed, 0 failed