### PR TITLE
Preserve rows below partial scroll regions

### DIFF
--- a/src/XTerm.NET.Tests/Buffer/BufferTests.cs
+++ b/src/XTerm.NET.Tests/Buffer/BufferTests.cs
@@ -990,6 +990,28 @@ public class BufferTests
     }
 
     [Fact]
+    public void ScrollUp_TopAnchoredPartialRegion_PreservesRowsBelowRegion()
+    {
+        var buffer = new TerminalBuffer(10, 5, 100);
+
+        SetCell(buffer, 0, "A");
+        SetCell(buffer, 1, "B");
+        SetCell(buffer, 2, "C");
+        SetCell(buffer, 3, "D");
+        SetCell(buffer, 4, ">");
+
+        buffer.SetScrollRegion(0, 3);
+        buffer.ScrollUp(1);
+
+        Assert.Equal(0, buffer.YBase);
+        Assert.Equal("B", buffer.GetLine(0)?[0].Content);
+        Assert.Equal("C", buffer.GetLine(1)?[0].Content);
+        Assert.Equal("D", buffer.GetLine(2)?[0].Content);
+        Assert.True(buffer.GetLine(3)?[0].IsSpace());
+        Assert.Equal(">", buffer.GetLine(4)?[0].Content);
+    }
+
+    [Fact]
     public void AlternateBuffer_NoScrollback_MultipleScrollOperations_YBaseRemainsZero()
     {
         // Arrange
@@ -1090,6 +1112,13 @@ public class BufferTests
         // Assert - YBase SHOULD increment because we have scrollback
         Assert.Equal(5, buffer.YBase);
         Assert.Equal(5, buffer.YDisp);
+    }
+
+    private static void SetCell(TerminalBuffer buffer, int row, string content)
+    {
+        var line = buffer.GetLine(row);
+        var cell = new BufferCell { Content = content, Width = 1 };
+        line?.SetCell(0, ref cell);
     }
 
     #endregion

--- a/src/XTerm.NET.Tests/Buffer/BufferTests.cs
+++ b/src/XTerm.NET.Tests/Buffer/BufferTests.cs
@@ -1,5 +1,6 @@
 using XTerm.Buffer;
 using XTerm.Common;
+using XTerm.Options;
 
 namespace XTerm.Tests.Buffer;
 
@@ -1009,6 +1010,54 @@ public class BufferTests
         Assert.Equal("D", buffer.GetLine(2)?[0].Content);
         Assert.True(buffer.GetLine(3)?[0].IsSpace());
         Assert.Equal(">", buffer.GetLine(4)?[0].Content);
+    }
+
+    [Fact]
+    public void InsertLines_WithScrollback_UsesActiveBufferCoordinates()
+    {
+        var terminal = new Terminal(new TerminalOptions { Cols = 10, Rows = 5, Scrollback = 100 });
+
+        terminal.Write("s1\r\ns2\r\ns3\r\ns4\r\ns5\r\n");
+        var yBase = terminal.Buffer.YBase;
+
+        SetCell(terminal.Buffer, yBase + 0, "A");
+        SetCell(terminal.Buffer, yBase + 1, "B");
+        SetCell(terminal.Buffer, yBase + 2, "C");
+        SetCell(terminal.Buffer, yBase + 3, "D");
+        SetCell(terminal.Buffer, yBase + 4, ">");
+
+        terminal.Write("\x1b[1;4r\x1b[1;1H\x1b[1L");
+
+        Assert.Equal(yBase, terminal.Buffer.YBase);
+        Assert.True(terminal.Buffer.GetLine(yBase + 0)?[0].IsSpace());
+        Assert.Equal("A", terminal.Buffer.GetLine(yBase + 1)?[0].Content);
+        Assert.Equal("B", terminal.Buffer.GetLine(yBase + 2)?[0].Content);
+        Assert.Equal("C", terminal.Buffer.GetLine(yBase + 3)?[0].Content);
+        Assert.Equal(">", terminal.Buffer.GetLine(yBase + 4)?[0].Content);
+    }
+
+    [Fact]
+    public void DeleteLines_WithScrollback_UsesActiveBufferCoordinates()
+    {
+        var terminal = new Terminal(new TerminalOptions { Cols = 10, Rows = 5, Scrollback = 100 });
+
+        terminal.Write("s1\r\ns2\r\ns3\r\ns4\r\ns5\r\n");
+        var yBase = terminal.Buffer.YBase;
+
+        SetCell(terminal.Buffer, yBase + 0, "A");
+        SetCell(terminal.Buffer, yBase + 1, "B");
+        SetCell(terminal.Buffer, yBase + 2, "C");
+        SetCell(terminal.Buffer, yBase + 3, "D");
+        SetCell(terminal.Buffer, yBase + 4, ">");
+
+        terminal.Write("\x1b[1;4r\x1b[1;1H\x1b[1M");
+
+        Assert.Equal(yBase, terminal.Buffer.YBase);
+        Assert.Equal("B", terminal.Buffer.GetLine(yBase + 0)?[0].Content);
+        Assert.Equal("C", terminal.Buffer.GetLine(yBase + 1)?[0].Content);
+        Assert.Equal("D", terminal.Buffer.GetLine(yBase + 2)?[0].Content);
+        Assert.True(terminal.Buffer.GetLine(yBase + 3)?[0].IsSpace());
+        Assert.Equal(">", terminal.Buffer.GetLine(yBase + 4)?[0].Content);
     }
 
     [Fact]

--- a/src/XTerm.NET.Tests/Buffer/BufferTests.cs
+++ b/src/XTerm.NET.Tests/Buffer/BufferTests.cs
@@ -1061,6 +1061,30 @@ public class BufferTests
     }
 
     [Fact]
+    public void DeleteLines_OutsideScrollRegion_PreservesReservedPromptRow()
+    {
+        var terminal = new Terminal(new TerminalOptions { Cols = 10, Rows = 5, Scrollback = 100 });
+
+        terminal.Write("s1\r\ns2\r\ns3\r\ns4\r\ns5\r\n");
+        var yBase = terminal.Buffer.YBase;
+
+        SetCell(terminal.Buffer, yBase + 0, "A");
+        SetCell(terminal.Buffer, yBase + 1, "B");
+        SetCell(terminal.Buffer, yBase + 2, "C");
+        SetCell(terminal.Buffer, yBase + 3, "D");
+        SetCell(terminal.Buffer, yBase + 4, ">");
+
+        terminal.Write("\x1b[1;4r\x1b[5;1H\x1b[1M");
+
+        Assert.Equal(yBase, terminal.Buffer.YBase);
+        Assert.Equal("A", terminal.Buffer.GetLine(yBase + 0)?[0].Content);
+        Assert.Equal("B", terminal.Buffer.GetLine(yBase + 1)?[0].Content);
+        Assert.Equal("C", terminal.Buffer.GetLine(yBase + 2)?[0].Content);
+        Assert.Equal("D", terminal.Buffer.GetLine(yBase + 3)?[0].Content);
+        Assert.Equal(">", terminal.Buffer.GetLine(yBase + 4)?[0].Content);
+    }
+
+    [Fact]
     public void AlternateBuffer_NoScrollback_MultipleScrollOperations_YBaseRemainsZero()
     {
         // Arrange

--- a/src/XTerm.NET.Tests/Buffer/BufferTests.cs
+++ b/src/XTerm.NET.Tests/Buffer/BufferTests.cs
@@ -1008,7 +1008,7 @@ public class BufferTests
         Assert.Equal("B", buffer.GetLine(0)?[0].Content);
         Assert.Equal("C", buffer.GetLine(1)?[0].Content);
         Assert.Equal("D", buffer.GetLine(2)?[0].Content);
-        Assert.True(buffer.GetLine(3)?[0].IsSpace());
+        Assert.True(buffer.GetLine(3)?[0].IsSpace() ?? false);
         Assert.Equal(">", buffer.GetLine(4)?[0].Content);
     }
 
@@ -1029,7 +1029,7 @@ public class BufferTests
         terminal.Write("\x1b[1;4r\x1b[1;1H\x1b[1L");
 
         Assert.Equal(yBase, terminal.Buffer.YBase);
-        Assert.True(terminal.Buffer.GetLine(yBase + 0)?[0].IsSpace());
+        Assert.True(terminal.Buffer.GetLine(yBase + 0)?[0].IsSpace() ?? false);
         Assert.Equal("A", terminal.Buffer.GetLine(yBase + 1)?[0].Content);
         Assert.Equal("B", terminal.Buffer.GetLine(yBase + 2)?[0].Content);
         Assert.Equal("C", terminal.Buffer.GetLine(yBase + 3)?[0].Content);
@@ -1056,7 +1056,7 @@ public class BufferTests
         Assert.Equal("B", terminal.Buffer.GetLine(yBase + 0)?[0].Content);
         Assert.Equal("C", terminal.Buffer.GetLine(yBase + 1)?[0].Content);
         Assert.Equal("D", terminal.Buffer.GetLine(yBase + 2)?[0].Content);
-        Assert.True(terminal.Buffer.GetLine(yBase + 3)?[0].IsSpace());
+        Assert.True(terminal.Buffer.GetLine(yBase + 3)?[0].IsSpace() ?? false);
         Assert.Equal(">", terminal.Buffer.GetLine(yBase + 4)?[0].Content);
     }
 

--- a/src/XTerm.NET/Buffer/TerminalBuffer.cs
+++ b/src/XTerm.NET/Buffer/TerminalBuffer.cs
@@ -140,11 +140,10 @@ public class TerminalBuffer
             // Create a new blank line that will be inserted at the bottom of the scroll region
             var newLine = GetBlankLine(AttributeData.Default, isWrapped);
 
-            // Only use the scrollback path if:
-            // 1. Scroll region starts at top (_scrollTop == 0)
-            // 2. We actually have scrollback capacity (MaxLength > _rows)
-            // For alternate buffer (no scrollback), always use the in-place scroll logic.
-            if (_scrollTop == 0 && _lines.MaxLength > _rows)
+            // Only the full-screen scroll region contributes to scrollback.
+            // Top-anchored partial regions reserve rows below the margin and
+            // must scroll in place so prompts/status rows are not promoted.
+            if (_scrollTop == 0 && _scrollBottom == _rows - 1 && _lines.MaxLength > _rows)
             {
                 // When scrollTop is 0, the top line goes into scrollback.
                 // In xterm.js: push new line first, then increment yBase and yDisp.

--- a/src/XTerm.NET/InputHandler.cs
+++ b/src/XTerm.NET/InputHandler.cs
@@ -915,7 +915,7 @@ public class InputHandler
 
         for (int i = 0; i < count; i++)
         {
-            _buffer.Lines.Splice(_buffer.ScrollBottom, 1);
+            _buffer.Lines.Splice(_buffer.YBase + _buffer.ScrollBottom, 1);
             _buffer.Lines.Splice(_buffer.Y + _buffer.YBase, 0,
                 _buffer.GetBlankLine(_curAttr));
         }
@@ -928,7 +928,7 @@ public class InputHandler
         for (int i = 0; i < count; i++)
         {
             _buffer.Lines.Splice(_buffer.Y + _buffer.YBase, 1);
-            _buffer.Lines.Splice(_buffer.ScrollBottom, 0,
+            _buffer.Lines.Splice(_buffer.YBase + _buffer.ScrollBottom, 0,
                 _buffer.GetBlankLine(_curAttr));
         }
     }

--- a/src/XTerm.NET/InputHandler.cs
+++ b/src/XTerm.NET/InputHandler.cs
@@ -924,6 +924,9 @@ public class InputHandler
     private void DeleteLines(Params parameters)
     {
         var count = Math.Max(parameters.GetParam(0, 1), 1);
+        // Only works in scroll region
+        if (_buffer.Y < _buffer.ScrollTop || _buffer.Y > _buffer.ScrollBottom)
+            return;
 
         for (int i = 0; i < count; i++)
         {


### PR DESCRIPTION
## Summary
- Treat only full-screen scroll regions as eligible for scrollback promotion
- Keep top-anchored partial scroll regions in-place so rows below the bottom margin are preserved
- Use active-buffer coordinates for `IL` / `CSI Ps L` and `DL` / `CSI Ps M` when normal-buffer scrollback exists
- Ignore `DL` / `CSI Ps M` when the cursor is outside the scroll region, matching `IL`
- Add regression tests covering reserved bottom prompt/status rows

## Why
Prompt-oriented terminal applications can reserve a bottom input/status row while scrolling output above it. A top-anchored partial scroll region must not promote the reserved row into scrollback.

The same visual artifact can occur after normal-buffer scrollback exists if insert/delete-line operations splice using viewport-relative `ScrollBottom` rather than `YBase + ScrollBottom`. In that case old scrollback rows can be edited instead of the active screen, allowing prompt/status content such as `>` or `>` to reappear higher in the viewport.

`DL` also needs the same scroll-region guard as `IL`; delete-line operations outside the active scroll region should be ignored so reserved prompt/status rows are not shifted.

## Tests
- `dotnet test src\XTerm.NET.slnx`