### PR TITLE
Fix DEC special graphics lower-right corner

### DIFF
--- a/src/XTerm.NET.Tests/InputHandlerTests.cs
+++ b/src/XTerm.NET.Tests/InputHandlerTests.cs
@@ -65,6 +65,21 @@ public class InputHandlerTests
     }
 
     [Fact]
+    public void Write_DecSpecialGraphics_MapsCornersCorrectly()
+    {
+        // Arrange
+        var terminal = CreateTerminal();
+
+        // Act
+        terminal.Write("\x1B(0jklmqx\x1B(Bj");
+
+        // Assert
+        var line = terminal.Buffer.Lines[0];
+        Assert.NotNull(line);
+        Assert.Equal("\u2518\u2510\u250c\u2514\u2500\u2502j", line.TranslateToString(true));
+    }
+
+    [Fact]
     public void HandleCsi_CursorUp_MovesCursor()
     {
         // Arrange

--- a/src/XTerm.NET/Common/Charsets.cs
+++ b/src/XTerm.NET/Common/Charsets.cs
@@ -14,7 +14,7 @@ public static class Charsets
     public static readonly Dictionary<char, string> VT100LineDrawing = new()
     {
         // Box Drawing Characters
-        { 'j', "\u250c" }, // ? Bottom right corner
+        { 'j', "\u2518" }, // ? Bottom right corner
         { 'k', "\u2510" }, // ? Top right corner
         { 'l', "\u250c" }, // ? Top left corner
         { 'm', "\u2514" }, // ? Bottom left corner


### PR DESCRIPTION
## Summary
- Correct the DEC Special Graphics mapping for `j` from top-left corner to lower-right corner.
- Add a regression test that exercises the real `ESC ( 0` parser path and verifies the corner, line, and ASCII-reset behavior.

## Why
VT100/xterm DEC Special Graphics maps `j` to the lower-right box-drawing corner. XTerm.NET was mapping it to the top-left corner, so terminal applications that use DEC line drawing could render boxes with the wrong corner glyph.

## Validation
- `dotnet test src\XTerm.NET.slnx`
  - 585 passed, 0 failed
  - Existing warnings remain for `EscapeSequenceParser.Dcs` and `Terminal.HyperlinkChanged`.